### PR TITLE
Added purchaseData to PurchaseResponse to enable validation of purchases

### DIFF
--- a/library/src/main/java/com/github/lukaspili/reactivebilling/PurchaseFlowService.java
+++ b/library/src/main/java/com/github/lukaspili/reactivebilling/PurchaseFlowService.java
@@ -83,15 +83,16 @@ public class PurchaseFlowService {
             ReactiveBillingLogger.log("Purchase flow result - response: %d (thread %s)", response, Thread.currentThread().getName());
 
             if (response == 0) {
-                Purchase purchase = PurchaseParser.parse(data.getStringExtra("INAPP_PURCHASE_DATA"));
+                String purchaseData = data.getStringExtra("INAPP_PURCHASE_DATA");
+                Purchase purchase = PurchaseParser.parse(purchaseData);
                 String signature = data.getStringExtra("INAPP_DATA_SIGNATURE");
-                subject.call(new PurchaseResponse(response, purchase, signature, extras, false));
+                subject.call(new PurchaseResponse(response, purchase, purchaseData, signature, extras, false));
             } else {
-                subject.call(new PurchaseResponse(response, null, null, extras, false));
+                subject.call(new PurchaseResponse(response, null, null, null, extras, false));
             }
         } else {
             ReactiveBillingLogger.log("Purchase flow result - CANCELED (thread %s)", Thread.currentThread().getName());
-            subject.call(new PurchaseResponse(-1, null, null, extras, true));
+            subject.call(new PurchaseResponse(-1, null, null, null, extras, true));
         }
     }
 }

--- a/library/src/main/java/com/github/lukaspili/reactivebilling/response/PurchaseResponse.java
+++ b/library/src/main/java/com/github/lukaspili/reactivebilling/response/PurchaseResponse.java
@@ -10,13 +10,15 @@ import com.github.lukaspili.reactivebilling.model.Purchase;
 public class PurchaseResponse extends Response {
 
     private final Purchase purchase;
+    private final String purchaseData;
     private final String signature;
     private final Bundle extras;
     private final boolean isCancelled;
 
-    public PurchaseResponse(int responseCode, Purchase purchase, String signature, Bundle extras, boolean isCancelled) {
+    public PurchaseResponse(int responseCode, Purchase purchase, String purchaseData, String signature, Bundle extras, boolean isCancelled) {
         super(responseCode);
         this.purchase = purchase;
+        this.purchaseData = purchaseData;
         this.signature = signature;
         this.extras = extras;
         this.isCancelled = isCancelled;
@@ -29,6 +31,10 @@ public class PurchaseResponse extends Response {
 
     public Purchase getPurchase() {
         return purchase;
+    }
+
+    public String getPurchaseData() {
+        return purchaseData;
     }
 
     public String getSignature() {


### PR DESCRIPTION
It doesn't validate anything yet, but now gives access to the raw purchase data that can be used to validate the signature.
#5
