### PR TITLE
Optionally attempt to restore purchases before starting purchase flow

### DIFF
--- a/library/src/main/java/com/github/lukaspili/reactivebilling/PurchaseFlowService.java
+++ b/library/src/main/java/com/github/lukaspili/reactivebilling/PurchaseFlowService.java
@@ -71,7 +71,7 @@ public class PurchaseFlowService {
         context.startActivity(intent);
     }
 
-    void onActivityResult(int resultCode, Intent data, Bundle extras) {
+    public void onActivityResult(int resultCode, Intent data, Bundle extras) {
         if (!hasSubscription) {
             throw new IllegalStateException("Subject cannot be null when receiving purchase result");
         }

--- a/library/src/main/java/com/github/lukaspili/reactivebilling/observable/GetBuyIntentObservable.java
+++ b/library/src/main/java/com/github/lukaspili/reactivebilling/observable/GetBuyIntentObservable.java
@@ -68,6 +68,8 @@ public class GetBuyIntentObservable extends BaseObservable<Response> {
                         purchaseFlowService.onActivityResult(Activity.RESULT_OK, data, new Bundle());
                         observer.onNext(response);
                         observer.onCompleted();
+
+                        ReactiveBilling.log(null, "Product was restored, purchase flow will not start (thread %s)", response.isSuccess(), Thread.currentThread().getName());
                         return;
                     }
                 }

--- a/library/src/main/java/com/github/lukaspili/reactivebilling/observable/GetBuyIntentObservable.java
+++ b/library/src/main/java/com/github/lukaspili/reactivebilling/observable/GetBuyIntentObservable.java
@@ -1,6 +1,8 @@
 package com.github.lukaspili.reactivebilling.observable;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.RemoteException;
 import android.support.annotation.NonNull;
@@ -10,8 +12,12 @@ import com.github.lukaspili.reactivebilling.BillingService;
 import com.github.lukaspili.reactivebilling.PurchaseFlowService;
 import com.github.lukaspili.reactivebilling.ReactiveBilling;
 import com.github.lukaspili.reactivebilling.model.PurchaseType;
+import com.github.lukaspili.reactivebilling.parser.PurchaseParser;
 import com.github.lukaspili.reactivebilling.response.GetBuyIntentResponse;
+import com.github.lukaspili.reactivebilling.response.GetPurchasesResponse;
 import com.github.lukaspili.reactivebilling.response.Response;
+
+import java.util.List;
 
 import rx.Observable;
 import rx.Observer;
@@ -45,20 +51,38 @@ public class GetBuyIntentObservable extends BaseObservable<Response> {
 
     @Override
     protected void onBillingServiceReady(BillingService billingService, Observer<? super Response> observer) {
-        GetBuyIntentResponse response;
+        GetBuyIntentResponse response = null;
         try {
-            response = billingService.getBuyIntent(productId, purchaseType, developerPayload);
+            boolean tryRestoreFirst = extras.getBoolean("TRY_RESTORE_FIRST", false);
+            GetPurchasesResponse purchasesResponse = billingService.getPurchases(purchaseType, null);
 
+            if (tryRestoreFirst && purchasesResponse.isSuccess()) {
+                List<GetPurchasesResponse.PurchaseResponse> purchasesList = purchasesResponse.getList();
+                for (GetPurchasesResponse.PurchaseResponse purchaseResponse : purchasesList) {
+                    if (purchaseResponse.getProductId().equals(productId)) {
+                        Intent data = new Intent();
+                        data.putExtra("INAPP_PURCHASE_DATA", PurchaseParser.toString(purchaseResponse.getPurchase()));
+                        data.putExtra("INAPP_DATA_SIGNATURE", purchaseResponse.getSignature());
+                        data.putExtra("RESPONSE_CODE", 0);
+
+                        purchaseFlowService.onActivityResult(Activity.RESULT_OK, data, new Bundle());
+                        observer.onNext(response);
+                        observer.onCompleted();
+                        return;
+                    }
+                }
+            }
+
+            response = billingService.getBuyIntent(productId, purchaseType, developerPayload);
             observer.onNext(response);
             observer.onCompleted();
+
+            ReactiveBilling.log(null, "Will start purchase flow: %b (thread %s)", response.isSuccess(), Thread.currentThread().getName());
+            if (response.isSuccess()) {
+                purchaseFlowService.startFlow(response.getIntent(), extras);
+            }
         } catch (RemoteException e) {
             observer.onError(e);
-            return;
-        }
-
-        ReactiveBilling.log(null, "Will start purchase flow: %b (thread %s)", response.isSuccess(), Thread.currentThread().getName());
-        if (response.isSuccess()) {
-            purchaseFlowService.startFlow(response.getIntent(), extras);
         }
     }
 }

--- a/library/src/main/java/com/github/lukaspili/reactivebilling/parser/PurchaseParser.java
+++ b/library/src/main/java/com/github/lukaspili/reactivebilling/parser/PurchaseParser.java
@@ -32,4 +32,24 @@ public class PurchaseParser {
                 json.optBoolean("autoRenewing")
         );
     }
+
+    public static String toString(Purchase purchase) {
+        JSONObject json = new JSONObject();
+
+        try {
+            json.putOpt("orderId", purchase.getOrderId());
+            json.putOpt("packageName", purchase.getPackageName());
+            json.putOpt("productId", purchase.getProductId());
+            json.putOpt("developerPayload", purchase.getDeveloperPayload());
+            json.putOpt("purchaseToken", purchase.getPurchaseToken());
+            json.putOpt("purchaseState", purchase.getPurchaseState().getValue());
+            json.putOpt("purchaseTime", purchase.getPurchaseTime());
+            json.putOpt("autoRenewing", purchase.isAutoRenewing());
+        } catch (JSONException e) {
+            ReactiveBilling.log(e, "Cannot create json from the Purchase object");
+            return null;
+        }
+
+        return json.toString();
+    }
 }


### PR DESCRIPTION
This adds the ability to first attempt to restore the purchase for the
given product and only if it wasn't purchased before, start the purchase
flow.

The rationale for this solution is that both flows (restore and
purchase) will have the exact same exit point - the Subscription to
purchaseFlow(), which is not necessarily at the same place as the
restore/purchase start logic and saves one extra codepath.

For example, consider a Fragment with custom View that has a 'Buy' button,
a RecyclerView  and an Adapter. The Fragment would hold the Subscription
to the purchaseFlow(), which triggers UI changes in the Adapter, and the
'Buy' button would have a click listener which triggers the
startPurchase().

Now if we want the 'Buy' button to do the restore first and only if
there's nothing to restore start the purchase, we'd need two different
paths on how to reach the Adapter - one is through the purchaseFlow()
Subscription, the second one would need to be some sort of callback from
the custom View back to the Fragment.

So combining these two different steps/paths into one with one single
return point makes things much easier.

Of course not everyone would want such logic so this would get triggered
only if TRY_RESTORE_FIRST=true is passed in the extras Bundle for the
startPurchase().

Cheers,
Martin from 500px